### PR TITLE
fix: expose email domain resource IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Default: `null`
 
 The following outputs are exported:
 
+### <a name="output_domain_resource_ids"></a> [domain\_resource\_ids](#output\_domain\_resource\_ids)
+
+Description: A map of the resource IDs for the deployed Email Communication Service domains, keyed by the same keys as `var.email_communication_service_domains`.
+
 ### <a name="output_resource"></a> [resource](#output\_resource)
 
 Description: The resource of email communication service

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "domain_resource_ids" {
+  description = "A map of the resource IDs for the deployed Email Communication Service domains, keyed by the same keys as `var.email_communication_service_domains`."
+  value       = { for k, v in azapi_resource.email_communication_service_domain : k => v.id }
+}
+
 output "resource" {
   description = "The resource of email communication service"
   value       = azapi_resource.email_communication_service

--- a/tests/unit/unit.tftest.hcl
+++ b/tests/unit/unit.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "azapi" {
+  mock_data "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+    }
+  }
+
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Communication/emailServices/ecs-test"
+    }
+  }
+}
+
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  name                = "ecs-test"
+  location            = "eastus"
+  resource_group_name = "rg-test"
+  data_location       = "United States"
+  enable_telemetry    = false
+
+  email_communication_service_domains = {
+    primary = {
+      name              = "example.com"
+      domain_management = "CustomerManaged"
+    }
+  }
+}
+
+run "domain_resource_ids_output" {
+  command = apply
+
+  override_resource {
+    target = azapi_resource.email_communication_service_domain["primary"]
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Communication/emailServices/ecs-test/domains/example.com"
+    }
+  }
+
+  assert {
+    condition     = output.domain_resource_ids == { primary = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Communication/emailServices/ecs-test/domains/example.com" }
+    error_message = "domain_resource_ids should expose the domain resource ID keyed by the same key used in var.email_communication_service_domains."
+  }
+}


### PR DESCRIPTION
## Description

Exposes Email Communication Service domain resource IDs as a map keyed by `email_communication_service_domains` input keys, allowing consumers to create Communication Services email domain associations without manually constructing child resource IDs.

Adds focused mocked unit coverage for the output and regenerates the module documentation.

Closes #30

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #30" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks